### PR TITLE
Use passive event listener if possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ const SwipeListener = function (element, options) {
     }
   }
 
-  element.addEventListener('touchmove', _touchmove);
+  element.addEventListener('touchmove', _touchmove, {passive: !options.preventScroll});
   element.addEventListener('touchend', _touchend);
 
   return {

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ const SwipeListener = function (element, options) {
 
     const xs = x[0], xe = x[x.length - 1], // Start and end x-coords
     ys = y[0], ye = y[y.length - 1];  // Start and end y-coords
-    
+
     const eventCoords = {
       x: [xs, xe],
       y: [ys, ye]
@@ -103,7 +103,7 @@ const SwipeListener = function (element, options) {
       const swipeReleaseEventData = {
         detail: eventCoords
       };
-      
+
       let swipeReleaseEvent = new CustomEvent('swiperelease', swipeReleaseEventData);
       element.dispatchEvent(swipeReleaseEvent);
     }
@@ -197,7 +197,7 @@ const SwipeListener = function (element, options) {
           ...eventCoords
         }
       };
-      
+
       let event = new CustomEvent('swipe', eventData);
       element.dispatchEvent(event);
     } else {
@@ -236,12 +236,24 @@ const SwipeListener = function (element, options) {
     }
   }
 
-  element.addEventListener('touchmove', _touchmove, {passive: !options.preventScroll});
+  // Test via a getter in the options object to see if the passive property is accessed
+  let passiveOptions = false;
+  try {
+    const testOptions = Object.defineProperty({}, 'passive', {
+      get: function () {
+        passiveOptions = {passive: !options.preventScroll};
+      }
+    });
+    window.addEventListener('testPassive', null, testOptions);
+    window.removeEventListener('testPassive', null, testOptions);
+  } catch (e) {}
+
+  element.addEventListener('touchmove', _touchmove, passiveOptions);
   element.addEventListener('touchend', _touchend);
 
   return {
     off: function () {
-      element.removeEventListener('touchmove', _touchmove);
+      element.removeEventListener('touchmove', _touchmove, passiveOptions);
       element.removeEventListener('touchend', _touchend);
       element.removeEventListener('mousedown', _mousedown);
       element.removeEventListener('mouseup', _mouseup);


### PR DESCRIPTION
Passive event listeners are a good practice and Chromium will warn you if not using one like this:
> [Violation] Added non-passive event listener to a scroll-blocking 'touchmove' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

There is only one place where you're calling `e.preventDefault()` and it depends on `options.preventScroll`. So whenever `options.preventScroll == false`, passive event listener can and should be used.